### PR TITLE
added tls secret, refer external secret name

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -107,8 +107,10 @@ spec:
           mountPath: {{ $config.config.schemeAdapter.env.JWS_VERIFICATION_KEYS_DIRECTORY }}
         - name: jws-private-key
           mountPath: "/jwsSigningKey/"
+        {{- if $config.config.schemeAdapter.secrets.sim_tls_secrets_name }}
         - name: tls-secrets
           mountPath: "/secrets/"
+        {{- end }}
         envFrom:
         - configMapRef:
             name: sim-{{ $name }}-scheme-adapter

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -24,10 +24,23 @@ spec:
       volumes:
       - name: jws-private-key
         secret:
+          {{- if $config.config.schemeAdapter.secrets.sim_jws_priv_key_secret_name }} 
+          secretName: {{ $config.config.schemeAdapter.secrets.sim_jws_priv_key_secret_name }}
+          {{- else }}
           secretName: sim-{{ $name }}-jws-priv-key
+          {{- end }}
       - name: jws-public-keys
         configMap:
+          {{- if $config.config.schemeAdapter.secrets.sim_jws_pub_keys_map_name }} 
+          name: {{ $config.config.schemeAdapter.secrets.sim_jws_pub_keys_map_name }}
+          {{- else }}
           name: sim-jws-public-keys
+          {{- end }}
+      {{- if $config.config.schemeAdapter.secrets.sim_tls_secrets_name }} 
+      - name: tls-secrets
+        secret:
+          secretName: {{ $config.config.schemeAdapter.secrets.sim_tls_secrets_name }}
+      {{- end }}
       containers:
       - name: backend
         image: "{{ $config.config.simBackend.image.repository }}:{{ $config.config.simBackend.image.tag }}"
@@ -94,6 +107,8 @@ spec:
           mountPath: {{ $config.config.schemeAdapter.env.JWS_VERIFICATION_KEYS_DIRECTORY }}
         - name: jws-private-key
           mountPath: "/jwsSigningKey/"
+        - name: tls-secrets
+          mountPath: "/secrets/"
         envFrom:
         - configMapRef:
             name: sim-{{ $name }}-scheme-adapter

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -126,10 +126,10 @@ defaults: &defaults
 
       env:
         # This option is presented for consistency with the .env file. However, for the purposes of this chart, this port is _not_ configurable.
-        # INBOUND_LISTEN_PORT: "4000"
+        INBOUND_LISTEN_PORT: "4000"
 
         # This option is presented for consistency with the .env file. However, for the purposes of this chart, this port is _not_ configurable.
-        # OUTBOUND_LISTEN_PORT: "4001"
+        OUTBOUND_LISTEN_PORT: "4001"
 
         # Enable mutual TLS authentication. Useful when not running in a secure
         # environment, i.e. when you're running it locally against your own implementation.


### PR DESCRIPTION
- Added a volume to load tls secret if one is supplied externally. This is probably not used in Mowali right now, but used for other labs
- Added a check for jws config map and secret to also load from external names if one is supplied